### PR TITLE
Real logger name

### DIFF
--- a/sonoff_lan_mode_r3/switch.py
+++ b/sonoff_lan_mode_r3/switch.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_ICON, CONF_API_KEY
 
 REQUIREMENTS = ['pysonofflanr3==1.1.3']
 
-_LOGGER = logging.getLogger('homeassistant.components.switch.sonoff_lan_mode_r3')
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Sonoff Switch'
 DEFAULT_ICON = 'mdi:flash'


### PR DESCRIPTION
With this PR the logger gets the real package name.
Due to the actual definition I was not able to correctly configure the log traces for this integration.