### PR TITLE
Add tested device

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is a simple platform to control switch devices which can normally only be c
  - Sonoff iFan02
  - Sonoff TH16
  - Sonoff SV
+ - Hoch/WDYK ZJSB9-80 Wifi
 
 ## Expected Supported devices:
 


### PR DESCRIPTION
I just successfully tested Wifi enabled circuit breaker WDYK ZJSB9-80 Wifi which is also available from Hoch. The device works without any problems out of the box. Firmware is 3.4.0.